### PR TITLE
fix(oauth): Fix environment variable resolution for auth tokens

### DIFF
--- a/packages/mcp/src/auth/implementations/bearer-token-provider.ts
+++ b/packages/mcp/src/auth/implementations/bearer-token-provider.ts
@@ -11,7 +11,10 @@ import {
   AuthErrorCode,
 } from '../errors/authentication-error.js';
 import { logEvent } from '../../logger.js';
-import { ValidationUtils } from '../../utils/validation-utils.js';
+import {
+  EnvironmentResolver,
+  resolveEnvironmentVariables,
+} from './environment-resolver.js';
 
 /**
  * Configuration interface for BearerTokenAuthProvider
@@ -22,6 +25,11 @@ export interface BearerTokenConfig {
    * Can include environment variable references like ${TOKEN_VAR}
    */
   token: string;
+  /**
+   * Optional environment object for resolving variables
+   * If not provided, uses process.env
+   */
+  env?: Record<string, string | undefined>;
 }
 
 /**
@@ -52,8 +60,8 @@ export class BearerTokenAuthProvider implements IAuthProvider {
     // Resolve environment variables in token
     let resolvedToken: string;
     try {
-      resolvedToken = ValidationUtils.hasEnvironmentVariables(config.token)
-        ? ValidationUtils.resolveEnvironmentVariables(config.token)
+      resolvedToken = EnvironmentResolver.containsVariables(config.token)
+        ? resolveEnvironmentVariables(config.token, { envSource: config.env })
         : config.token;
     } catch (error) {
       throw new AuthenticationError(

--- a/packages/mcp/src/auth/implementations/environment-resolver.ts
+++ b/packages/mcp/src/auth/implementations/environment-resolver.ts
@@ -171,26 +171,6 @@ export class EnvironmentResolver {
   }
 
   /**
-   * Creates a resolver with default configuration for OAuth scenarios
-   */
-  static createDefault(): EnvironmentResolver {
-    return new EnvironmentResolver({
-      maxDepth: 5,
-      strict: true,
-    });
-  }
-
-  /**
-   * Creates a resolver with relaxed configuration (non-strict mode)
-   */
-  static createRelaxed(): EnvironmentResolver {
-    return new EnvironmentResolver({
-      maxDepth: 5,
-      strict: false,
-    });
-  }
-
-  /**
    * Utility method to check if a string contains environment variable patterns
    */
   static containsVariables(value: string): boolean {
@@ -207,15 +187,4 @@ export function resolveEnvironmentVariables(
 ): string {
   const resolver = new EnvironmentResolver(config);
   return resolver.resolve(value);
-}
-
-/**
- * Convenience function to resolve environment variables in an object
- */
-export function resolveEnvironmentObject<T extends Record<string, unknown>>(
-  config: T,
-  resolverConfig?: EnvironmentResolverConfig,
-): T {
-  const resolver = new EnvironmentResolver(resolverConfig);
-  return resolver.resolveObject(config);
 }

--- a/packages/mcp/src/config.ts
+++ b/packages/mcp/src/config.ts
@@ -172,10 +172,26 @@ export const WebSocketTransportConfigSchema = z.object({
     .optional(),
 });
 
+export const StreamableHTTPTransportConfigSchema = z.object({
+  type: z.literal('streamable-http'),
+  url: z.string(),
+  timeout: z.number().optional(),
+  reconnect: z
+    .object({
+      maxAttempts: z.number().optional(),
+      initialDelayMs: z.number().optional(),
+      maxDelayMs: z.number().optional(),
+      backoffMultiplier: z.number().optional(),
+    })
+    .optional(),
+  sessionId: z.string().optional(),
+});
+
 export const TransportConfigSchema = z.discriminatedUnion('type', [
   StdioTransportConfigSchema,
   SSETransportConfigSchema,
   WebSocketTransportConfigSchema,
+  StreamableHTTPTransportConfigSchema,
 ]);
 
 // Target server schema that includes auth and transport

--- a/packages/mcp/src/proxy/mcp-proxy.ts
+++ b/packages/mcp/src/proxy/mcp-proxy.ts
@@ -355,6 +355,7 @@ export class MCPProxy extends EventEmitter {
   private createAuthProvider(
     authConfig?: AuthConfigZod,
     serverName?: string,
+    resolvedEnv?: Record<string, string>,
   ): AuthProviderResult | undefined {
     if (!authConfig || authConfig.type === 'none') {
       return undefined;
@@ -363,7 +364,10 @@ export class MCPProxy extends EventEmitter {
     switch (authConfig.type) {
       case 'bearer': {
         return {
-          provider: new BearerTokenAuthProvider({ token: authConfig.token }),
+          provider: new BearerTokenAuthProvider({
+            token: authConfig.token,
+            env: resolvedEnv,
+          }),
         };
       }
       case 'oauth2-client': {
@@ -670,6 +674,7 @@ export class MCPProxy extends EventEmitter {
     const authResult = this.createAuthProvider(
       extendedServer.auth,
       extendedServer.name,
+      resolvedEnv,
     );
 
     const transportDependencies = authResult

--- a/packages/mcp/src/transports/transport-factory.ts
+++ b/packages/mcp/src/transports/transport-factory.ts
@@ -23,6 +23,10 @@ import { SSEClientTransport } from './implementations/sse-client-transport.js';
 import { WebSocketClientTransport } from './implementations/websocket-client-transport.js';
 import { StreamableHTTPClientTransport } from './implementations/streamable-http-client-transport.js';
 import { ValidationUtils } from '../utils/validation-utils.js';
+import {
+  EnvironmentResolver,
+  resolveEnvironmentVariables as resolveEnv,
+} from '../auth/implementations/environment-resolver.js';
 
 /**
  * Dependencies that can be injected into transports
@@ -323,8 +327,8 @@ function resolveEnvironmentVariables(
   // Helper function to resolve variables in a string
   const resolveString = (value: string): string => {
     try {
-      return ValidationUtils.hasEnvironmentVariables(value)
-        ? ValidationUtils.resolveEnvironmentVariables(value)
+      return EnvironmentResolver.containsVariables(value)
+        ? resolveEnv(value)
         : value;
     } catch (error) {
       throw TransportError.serverError(

--- a/packages/mcp/src/utils/validation-utils.ts
+++ b/packages/mcp/src/utils/validation-utils.ts
@@ -4,7 +4,6 @@
 
 // Security validation for serverId (from keychain-token-storage.ts)
 const SAFE_SERVER_ID_REGEX = /^[a-zA-Z0-9._-]+$/;
-const ENV_VAR_REGEX = /\$\{([^}]+)\}/g;
 
 export class ValidationUtils {
   /**
@@ -50,29 +49,6 @@ export class ValidationUtils {
   }
 
   /**
-   * Resolves environment variables in a string
-   * Format: ${ENV_VAR_NAME}
-   */
-  static resolveEnvironmentVariables(value: string): string {
-    return value.replace(ENV_VAR_REGEX, (match, envVar) => {
-      const envValue = process.env[envVar];
-      if (envValue === undefined) {
-        throw new Error(`Environment variable ${envVar} is not defined`);
-      }
-      return envValue;
-    });
-  }
-
-  /**
-   * Checks if a string contains environment variables
-   */
-  static hasEnvironmentVariables(value: string): boolean {
-    // Reset regex state since it has global flag
-    ENV_VAR_REGEX.lastIndex = 0;
-    return ENV_VAR_REGEX.test(value);
-  }
-
-  /**
    * Validates required config fields
    */
   static validateRequired<T>(
@@ -109,4 +85,3 @@ export class ValidationUtils {
 
 // Export regex patterns for cases where direct regex access is needed
 export const SAFE_SERVER_ID_REGEX_PATTERN = SAFE_SERVER_ID_REGEX;
-export const ENV_VAR_REGEX_PATTERN = ENV_VAR_REGEX;

--- a/packages/mcp/test/unit/validation-utils.test.ts
+++ b/packages/mcp/test/unit/validation-utils.test.ts
@@ -106,59 +106,6 @@ describe('ValidationUtils', () => {
     });
   });
 
-  describe('resolveEnvironmentVariables', () => {
-    it('should resolve environment variables', () => {
-      process.env.TEST_VAR = 'test-value';
-      const result = ValidationUtils.resolveEnvironmentVariables(
-        'prefix-${TEST_VAR}-suffix',
-      );
-      expect(result).toBe('prefix-test-value-suffix');
-    });
-
-    it('should handle multiple environment variables', () => {
-      process.env.VAR1 = 'value1';
-      process.env.VAR2 = 'value2';
-      const result =
-        ValidationUtils.resolveEnvironmentVariables('${VAR1}-${VAR2}');
-      expect(result).toBe('value1-value2');
-    });
-
-    it('should return original string if no variables', () => {
-      const result =
-        ValidationUtils.resolveEnvironmentVariables('no-variables-here');
-      expect(result).toBe('no-variables-here');
-    });
-
-    it('should throw for undefined environment variables', () => {
-      expect(() => {
-        ValidationUtils.resolveEnvironmentVariables('${UNDEFINED_VAR}');
-      }).toThrow('Environment variable UNDEFINED_VAR is not defined');
-    });
-  });
-
-  describe('hasEnvironmentVariables', () => {
-    it('should detect environment variables', () => {
-      expect(ValidationUtils.hasEnvironmentVariables('${VAR}')).toBe(true);
-      expect(
-        ValidationUtils.hasEnvironmentVariables('prefix-${VAR}-suffix'),
-      ).toBe(true);
-      expect(ValidationUtils.hasEnvironmentVariables('${VAR1}-${VAR2}')).toBe(
-        true,
-      );
-    });
-
-    it('should return false for strings without variables', () => {
-      expect(ValidationUtils.hasEnvironmentVariables('no-variables')).toBe(
-        false,
-      );
-      expect(
-        ValidationUtils.hasEnvironmentVariables('missing-braces-VAR'),
-      ).toBe(false);
-      expect(ValidationUtils.hasEnvironmentVariables('${incomplete')).toBe(
-        false,
-      );
-    });
-  });
 
   describe('validateRequired', () => {
     it('should accept objects with all required fields', () => {


### PR DESCRIPTION
Streamlined environment variable resolution to eliminate DRY violations and follow SEAMS principle:

- Single source of truth: EnvironmentResolver handles all environment resolution
- Removed duplicate resolution logic from ValidationUtils (now only validates)
- Auth providers now receive resolved environment from secret providers
- Fixed issue where Bearer tokens couldn't access .env file variables

This fixes the issue where ${GITHUB_PERSONAL_ACCESS_TOKEN} from .env wasn't being resolved because auth providers were created before secret providers loaded the environment.