### PR TITLE
fix(release): run build before pack to prevent stale dist publication

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -24,6 +24,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/commands/core/package.json
+++ b/packages/commands/core/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/commands/js-debugger/package.json
+++ b/packages/commands/js-debugger/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz",
     "typedoc": "typedoc",

--- a/packages/commands/npm-lookup/package.json
+++ b/packages/commands/npm-lookup/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/commands/ts-validate/package.json
+++ b/packages/commands/ts-validate/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/commands/vitest/package.json
+++ b/packages/commands/vitest/package.json
@@ -34,6 +34,7 @@
   "scripts": {
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -37,6 +37,7 @@
     "dev": "tsx src/cli.ts",
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -27,6 +27,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   }

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -24,6 +24,7 @@
     "dev": "tsx src/index.ts",
     "build": "tsx build.ts",
     "build:watch": "tsx build.ts --watch",
+    "prepack": "yarn build",
     "test": "echo 'ERROR: Tests must be run via `yarn test` from repository root!' && exit 1",
     "release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
   },


### PR DESCRIPTION
## Summary
Adds `"prepack": "yarn build"` to every publishable workspace package, so any path that produces a tarball (`yarn pack`, `npm pack`, `npm publish`) regenerates `dist/` from source first.

## Why this PR exists
`mcp-funnel@0.0.8` on npm currently ships a stale bundle that predates PR #93 (commit `01a0b4f`) — even though the source on git tag `v0.0.8` has the fix correctly applied.

Empirical comparison (rebuild from current `develop` vs. `npm install mcp-funnel@0.0.8`):

| Location | `StdioClientTransport` constructor | `setProtocolVersion` |
|---|---|---|
| Source on `develop` / tag `v0.0.8` | empty (with explicit "do not set sessionId here" comment, lines 60–76) | sets `this.sessionId = RequestUtils.generateSessionId()` |
| Fresh `yarn build` output (`packages/mcp/dist/cli.js`) | empty | sets `this.sessionId = generateSessionId()` |
| Published npm tarball `mcp-funnel@0.0.8` (verifiable on unpkg) | sets `this.sessionId = \`stdio-${Date.now()}-${Math.random().toString(36).substr(2, 9)}\`` | does **not** set sessionId |

The published bundle predates **both** #93 (the fix) and `73c2d84` (the UUID-v4 refactor), so it was built from source older than either commit and never regenerated before publish.

## User impact
Because the MCP TypeScript SDK skips the `initialize`/`initialized` handshake in `client.connect()` whenever `transport.sessionId` is already truthy, every Python/FastMCP-based MCP server (which strictly requires the handshake to complete first) silently fails to register tools when funnel is installed via `npm install` / `npx mcp-funnel`. Confirmed cases:
- `mcp-server-qdrant` (FastMCP): `tools/list` returns 0 tools through the funnel installed from npm; returns 2 tools (`qdrant-find`, `qdrant-store`) through funnel rebuilt from current source.
- `redis-mcp-server` (FastMCP): same pattern (47 tools through fresh build, 0 through npm install).
- Cloudflare `observability.mcp.cloudflare.com` (FastMCP): same pattern (10 tools through fresh build, 0 through npm install).

Node-based MCP servers (e.g. `@modelcontextprotocol/server-filesystem`) tolerate the missing handshake, which is why this regression was invisible until someone wired up Python servers.

## Root cause of the published-bundle drift
Each publishable workspace currently has:
```json
"release": "yarn npm audit && yarn pack -o out/out.tgz && npm publish --access public ./out/out.tgz"
```
There is no `yarn build` between source changes and `pack`, and no `prepack` hook. If `release` is invoked at the workspace level (or `dist/` is otherwise stale on disk), the resulting tarball ships whatever happens to be there — which in v0.0.8 predates #93.

The repo root `release` does start with `yarn build`, so this only manifests when a workspace-level `release` runs without a fresh root build. A `prepack` hook closes that gap.

## Fix
Add `"prepack": "yarn build"` to all 10 publishable workspace packages:
- `packages/auth`, `packages/core`, `packages/mcp`, `packages/models`, `packages/schemas`
- `packages/commands/{core,js-debugger,npm-lookup,ts-validate,vitest}`

Skipped `packages/server` and `packages/web` since they have no `release` script and their publishing path (if any) is unclear — happy to add them in a follow-up if desired.

`prepack` (rather than `prepublishOnly`) was chosen so `yarn pack` invocations (which the existing `release` script uses) are also covered, not only `npm publish`.

## Verification
- [x] Existing `yarn build` from clean checkout still succeeds end-to-end
- [x] `rm -rf packages/mcp/dist && yarn workspace mcp-funnel pack -o /tmp/test.tgz` produces a tarball where `dist/cli.js` has the post-#93 shape (constructor empty, `setProtocolVersion` sets sessionId via `generateSessionId()`)
- [x] Smoke-tested funnel built from current `develop` against three FastMCP servers (mcp-server-qdrant, redis-mcp-server, Cloudflare observability) — `tools/list` returns expected tools (2 / 47 / 10 respectively, vs. 0 from `mcp-funnel@0.0.8` on npm)

## Follow-up
Filing a separate issue tracking the v0.0.8 stale-bundle situation and requesting a republish (or `0.0.8.1` / `0.0.9`) once this lands; will link from here.

## References
- PR #93 (`01a0b4f`): defer sessionId to setProtocolVersion
- `73c2d84`: switch sessionId to UUID v4
- `12d44ef`: release v0.0.8